### PR TITLE
Set pages to be `force-static` to have faster route transition time

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-static';
+
 import { ContactForm } from '@/components/about/contact-form';
 import { FeatureCard } from '@/components/about/feature-card';
 import { XPadletLink } from '@/components/ui/link/';

--- a/src/app/dashboard/new/page.tsx
+++ b/src/app/dashboard/new/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-static';
+
 import { DashboardHeader } from '@/components/dashboard/dashboard-header';
 import { CreateTodoListForm } from '@/components/todo-lists/create-todo-list-form';
 

--- a/src/app/study/page.tsx
+++ b/src/app/study/page.tsx
@@ -1,3 +1,4 @@
+export const dynamic = 'force-static';
 import Link from 'next/link';
 
 export default function StudyPage() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated several pages to ensure they are always statically rendered, improving consistency in page loading and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->