### PR TITLE
Preconnct to S3 URLs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,7 +26,31 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'youtube.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'xwing-daryll.s3.us-east-1.amazonaws.com',
+      },
     ],
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Link',
+            value: [
+              '<https://fonts.googleapis.com>; rel=preconnect',
+              '<https://fonts.gstatic.com>; rel=preconnect',
+              '<https://www.google-analytics.com>; rel=preconnect',
+              '<https://www.youtube.com>; rel=preconnect',
+              '<https://i.ytimg.com>; rel=preconnect',
+              '<https://xwing-daryll.s3.us-east-1.amazonaws.com>; rel=preconnect',
+            ].join(','),
+          },
+        ],
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
Confirmation that we are preconnecting in Safari

Reference - https://andydavies.me/blog/2019/04/17/three-ways-of-checking-your-rel-equals-preconnect-resource-hints-are-working/


- ![CleanShot 2025-04-29 at 20 38 45](https://github.com/user-attachments/assets/e77e5089-9fd8-4386-abde-7d3972d30644)

Actual results

![CleanShot 2025-04-29 at 20 54 01](https://github.com/user-attachments/assets/f998c7bb-6f40-470c-b195-7644757abb4f)

![CleanShot 2025-04-29 at 21 10 23](https://github.com/user-attachments/assets/86febbb1-9bdf-4da2-bd9f-ec5d248f1497)




## Summary by CodeRabbit

- **New Features**
	- Improved image loading support by allowing images from an additional external source.
	- Enhanced site performance by introducing preconnection hints for various external services, including font providers, analytics, YouTube, and the new image source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->