### PR TITLE
Try to not load all fonts at the start

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,7 +26,31 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'youtube.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'xwing-daryll.s3.us-east-1.amazonaws.com',
+      },
     ],
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Link',
+            value: [
+              '<https://fonts.googleapis.com>; rel=preconnect',
+              '<https://fonts.gstatic.com>; rel=preconnect',
+              '<https://www.google-analytics.com>; rel=preconnect',
+              '<https://www.youtube.com>; rel=preconnect',
+              '<https://i.ytimg.com>; rel=preconnect',
+              '<https://xwing-daryll.s3.us-east-1.amazonaws.com>; rel=preconnect',
+            ].join(','),
+          },
+        ],
+      },
+    ];
   },
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,24 +3,11 @@ import { DevBanner } from '@/components/DevBanner';
 import { NavBar } from '@/components/navigation/nav-bar';
 import { Providers } from '@/components/Providers';
 import { Toaster } from '@/components/ui/sonner';
+import { cn } from '@/lib/utils';
 import type { Metadata } from 'next';
-import { Inter, Montserrat, Open_Sans, Playpen_Sans, Poppins, Roboto } from 'next/font/google';
-import NextTopLoader from 'nextjs-toploader';
+import { Montserrat } from 'next/font/google';
 
-const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
-const roboto = Roboto({
-  weight: ['400', '500', '700'],
-  subsets: ['latin'],
-  variable: '--font-roboto',
-});
-const openSans = Open_Sans({ subsets: ['latin'], variable: '--font-open-sans' });
 const montserrat = Montserrat({ subsets: ['latin'], variable: '--font-montserrat' });
-const poppins = Poppins({
-  weight: ['400', '500', '700'],
-  subsets: ['latin'],
-  variable: '--font-poppins',
-});
-const playpen = Playpen_Sans({ subsets: ['latin'], variable: '--font-playpen' });
 
 export const metadata: Metadata = {
   title: 'Puglet - Mock Padlet',
@@ -39,17 +26,16 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body>
+    <html lang="en" suppressHydrationWarning>
+      <body className={cn(montserrat.variable, 'font-sans')}>
         <Providers>
-          <Toaster />
           <DevBanner />
           <div className="flex min-h-screen flex-col">
             <NavBar />
-            <NextTopLoader />
 
             <main className="flex-1">{children}</main>
           </div>
+          <Toaster />
         </Providers>
       </body>
     </html>

--- a/src/components/navigation/nav-links.tsx
+++ b/src/components/navigation/nav-links.tsx
@@ -17,7 +17,7 @@ export function NavLinks() {
         return (
           <XPadletLink variant="muted" href={item.href} key={item.href}>
             <Button
-              variant={pathname === item.href ? 'default' : 'ghost'}
+              variant={pathname.startsWith(item.href) ? 'default' : 'ghost'}
               className={cn('flex items-center', 'aria-[current=page]:pointer-events-none')}
               aria-current={item.href === pathname ? 'page' : undefined}
             >

--- a/src/components/todo-lists/todo-list-appearance-editor.tsx
+++ b/src/components/todo-lists/todo-list-appearance-editor.tsx
@@ -14,21 +14,45 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import { isObjectKeysTraversing } from '@/lib/utils/is-object-keys-traversing';
 import { TAILWIND_THEME_COLORS, TodoList } from '@/types/todo-list';
 import { Settings2 } from 'lucide-react';
+import { Inter, Open_Sans, Playpen_Sans, Poppins, Roboto } from 'next/font/google';
 import { ComponentProps, useState } from 'react';
 import { useMount } from 'react-use';
 import { DisplayModeSelector } from '../todo-lists/display-mode-selector';
 import { QRCode } from '../ui/qr-code';
 
+// Initialize fonts with preload: false
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter', preload: false });
+const roboto = Roboto({
+  weight: ['400', '500', '700'],
+  subsets: ['latin'],
+  variable: '--font-roboto',
+  preload: false,
+});
+const openSans = Open_Sans({ subsets: ['latin'], variable: '--font-open-sans', preload: false });
+const poppins = Poppins({
+  weight: ['400', '500', '700'],
+  subsets: ['latin'],
+  variable: '--font-poppins',
+  preload: false,
+});
+const playpen = Playpen_Sans({ subsets: ['latin'], variable: '--font-playpen', preload: false });
+
 const FONTS = {
-  Inter: 'Inter, sans-serif',
-  Roboto: 'Roboto, sans-serif',
-  'Open Sans': 'Open Sans, sans-serif',
-  Montserrat: 'Montserrat, sans-serif',
-  Poppins: 'Poppins, sans-serif',
-  Playpen_Sans: 'Playpen Sans, sans-serif',
+  Inter: inter,
+  Roboto: roboto,
+  'Open Sans': openSans,
+  Montserrat: 'Montserrat, sans-serif', // This one is already loaded in layout.tsx
+  Poppins: poppins,
+  Playpen_Sans: playpen,
 } as const;
 
 type Font = keyof typeof FONTS;
+
+// Helper function to get font family
+const getFontFamily = (font: Font): string => {
+  const fontObj = FONTS[font];
+  return typeof fontObj === 'string' ? fontObj : fontObj.style.fontFamily;
+};
 
 interface TodoListAppearanceEditorProps extends ComponentProps<typeof Sheet> {
   themeColor: TodoList['theme'];
@@ -120,10 +144,10 @@ export function TodoListAppearanceEditor({
                 setPreviewSettings((prev) => ({ ...prev, font: e.target.value as Font }))
               }
               className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus:ring-2 focus:ring-slate-400 focus:outline-none"
-              style={{ fontFamily: FONTS[previewSettings.font] }}
+              style={{ fontFamily: getFontFamily(previewSettings.font) }}
             >
               {Object.keys(FONTS).map((font) => (
-                <option key={font} value={font} style={{ fontFamily: FONTS[font as Font] }}>
+                <option key={font} value={font} style={{ fontFamily: getFontFamily(font as Font) }}>
                   {font}
                 </option>
               ))}


### PR DESCRIPTION
Removed all the random fonts that were loading at the start - we load the font now when we actually open the `AppearanceEditor`.

https://www.webpagetest.org/video/compare.php?tests=250429_AiDcYD_8GA,250429_BiDc3T_8C9

![CleanShot 2025-04-30 at 00 39 12](https://github.com/user-attachments/assets/16a4a353-c273-4e69-8683-3b1ca18f2c92)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved remote image support and loading performance by allowing additional external image sources and adding preconnect hints for various origins.

- **Style**
  - Simplified font usage across the app by retaining only the Montserrat font globally.
  - Updated navigation styling to highlight buttons based on broader URL matches.

- **Chores**
  - Reordered and cleaned up UI components for better structure and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->